### PR TITLE
merge CopeX fork into main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,56 @@
 ## ReesSolutions DBOverride
 
-Override Module to allow MariaDB 10.5 to 10.11 support for development.
+Override Module to allow MariaDB 10.5 to 11.x support for development.
 Now available via https://packagist.org/
 
-### Use this module at your own risk in production. Versions higher than MariaDB 10.4 have no offical support.
+### Use this module at your own risk in production. Versions higher than MariaDB 10.4 have no official support.
+
+#### Version Compatibility Matrix
+
+| MariaDB Version | Support Status              |
+| --------------- | --------------------------- |
+| 10.2 - 10.11    | ✅ Supported                |
+| 11.x            | ✅ Supported (Experimental) |
+| 11.4.8          | ✅ Tested                   |
 
 #### Installation
-* Require the Module
-``` composer require reessolutions/db-override:* ```
+
+- Require the Module
+  `composer require reessolutions/db-override:*`
+
+#### Configuration
+
+The module automatically supports the following database versions:
+
+- MySQL 5.7.x
+- MySQL 8.0.x
+- MariaDB 10.2-10.11
+- MariaDB 11.x (including 11.4.8)
+
+#### Usage
+
+After installation, the module will automatically allow Magento to connect to unsupported MariaDB versions.
+No additional configuration is required.
+
+#### Troubleshooting
+
+If you encounter issues with MariaDB 11.4.8:
+
+1. Ensure you're using the latest version of this module
+2. Clear Magento cache: `bin/magento cache:flush`
+3. Check Magento logs for specific error messages
+4. Verify your MariaDB installation is functioning correctly
+
+#### Migration Notes
+
+When upgrading from MariaDB 10.x to 11.x:
+
+- Backup your database before upgrading
+- Test in a development environment first
+- Review MariaDB 11.x release notes for breaking changes
+- Update your database configuration if needed
+
+#### Support
+
+This module is provided as-is for development purposes. For production environments,
+it's recommended to use officially supported database versions.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "reessolutions/db-override",
-    "description": "A module to enable experimental mariadb 10.5 & 10.6 support before offical support is available.",
+    "description": "A module to enable experimental MariaDB 10.5-11.x support before official support is available.",
     "type": "magento2-module",
-    "version": "1.0.7",
+    "version": "1.1.0",
     "minimum-stability": "stable",
     "license": "gpl-3.0",
     "authors": [

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,11 +1,12 @@
-<?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\DB\Adapter\SqlVersionProvider">
         <arguments>
             <argument name="supportedVersionPatterns" xsi:type="array">
                 <item name="MySQL-8" xsi:type="string">^8\.[0-1]\.</item>
                 <item name="MySQL-5.7" xsi:type="string">^5\.7\.</item>
                 <item name="MariaDB-(10.2-10.11)" xsi:type="string">^10\.([2-9]|10|11)\.</item>
+                <item name="MariaDB-11.x" xsi:type="string">^11\.</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
merges CopeX fork into main module
allows for MariaDB 11.X usage

Thanks @CopeX for the useful fork.